### PR TITLE
Add Express API with React frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+client/node_modules/
+server/node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Ignore installed dependencies
 node_modules/
 client/node_modules/
 server/node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# Medicheck-dashboard
+# Medicheck Dashboard
+
+This project demonstrates a simple Express API and React frontend.
+
+## Setup
+
+Install dependencies for both server and client:
+
+```bash
+cd server && npm install
+cd ../client && npm install
+```
+
+## Running
+
+Start the API server and the React development server in separate terminals:
+
+```bash
+# Terminal A
+cd server
+npm start
+
+# Terminal B
+cd client
+npm start
+```
+
+Visit <http://localhost:3000> and you should see `API OK` rendered.

--- a/README.md
+++ b/README.md
@@ -26,3 +26,13 @@ npm start
 ```
 
 Visit <http://localhost:3000> and you should see `API OK` rendered.
+
+## Fetching openFDA data
+
+An additional route `/api/510k` fetches sample records from the openFDA
+database. This uses `node-fetch` in the server. After installing
+dependencies you can test the endpoint directly:
+
+```bash
+curl http://localhost:8787/api/510k
+```

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "medicheck-client",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build"
+  },
+  "proxy": "http://localhost:8787"
+}

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Medicheck App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,0 +1,11 @@
+import { useEffect, useState } from 'react';
+
+function App() {
+  const [msg, setMsg] = useState('');
+  useEffect(() => {
+    fetch('/api/hello').then(r => r.json()).then(d => setMsg(d.msg));
+  }, []);
+  return <h1>{msg || 'Loading…'}</h1>;
+}
+
+export default App;

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/server/fetchers/openfda.js
+++ b/server/fetchers/openfda.js
@@ -1,0 +1,8 @@
+const fetch = (...args) => import('node-fetch').then(({default: f}) => f(...args));
+
+module.exports = async function get510k() {
+  const url = 'https://api.fda.gov/device/510k.json?search=product_code:OBR&limit=5';
+  const res = await fetch(url);
+  const json = await res.json();
+  return json.results.map(r => ({ kNo: r.k_number, name: r.device_name }));
+};

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const get510k = require('./fetchers/openfda');
+const app = express();
+
+app.get('/api/hello', (_, res) => res.json({ msg: 'API OK' }));
+app.get('/api/510k', async (_, res) => res.json(await get510k()));
+
+app.listen(8787, () => console.log('Server on 8787'));

--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,4 @@
+// Basic Express server exposing simple API routes
 const express = require('express');
 const get510k = require('./fetchers/openfda');
 const app = express();

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "medicheck-server",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "node-fetch": "^3.4.1"
+  }
+}


### PR DESCRIPTION
## Summary
- add Express server with `/api/hello` and `/api/510k`
- add fetcher for openFDA device 510k endpoint
- scaffold React app that calls the `/api/hello` API
- document usage in README
- ignore node modules

## Testing
- `node index.js` *(fails: Cannot find module 'express' because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68824a8941408323a6618b282633b7ba